### PR TITLE
Stop a crash when and call to prepareToFork()

### DIFF
--- a/lib/Phpfastcache/Extensions/Drivers/Couchbasev4/Driver.php
+++ b/lib/Phpfastcache/Extensions/Drivers/Couchbasev4/Driver.php
@@ -148,6 +148,10 @@ class Driver implements AggregatablePoolInterface
      */
     public static function prepareToFork(): void
     {
+        if (!isset(static::$posixLoaded) && !isset(static::$extVersion)) {
+            return;
+        }
+
         if (!static::$posixLoaded) {
             throw new PhpfastcacheDriverCheckException('POSIX extension is required to prepare for forking');
         }


### PR DESCRIPTION
When switching drivers between envioments, allow calls to ```prepareToFork()``` without crashing when couchbase4 driver is not initialized.