### PR TITLE
Notify parent and child process at the same time

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
         ext-versions: ['couchbase-4.1.6', 'couchbase']
     name: PHP ${{ matrix.php-versions }} using ${{ matrix.ext-versions }} quality/tests on ${{ matrix.operating-system }}
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 9.2.3
+#### 27 November 2024
+- __Driver Core__
+  - `Couchbasev4` Allow call to `handleNotifyFork()` after process has been forked, this is due 
+  - to a change in the couchbase SDK that needs parent and child to be notified at the same time.
+
+
 ## 9.2.2
 #### 29 July 2024
 - __Driver Core__

--- a/README.md
+++ b/README.md
@@ -33,13 +33,16 @@ composer install phpfastcache/couchbasev4-extension
 
 To fork a php process correctly you will need to tell the Couchbase diver to prepare for the fork.
 
-⚠️ __WARNING__ You **must** call the drivers `Phpfastcache\Drivers\Couchbasev4\Driver::prepareToFork()` just before the `pcntl_fork()` call or the child process will lock up.
+⚠️ __WARNING__ You **must** call the drivers `Phpfastcache\Drivers\Couchbasev4\Driver::prepareToFork()` 
+just before the `pcntl_fork()` call or the child process will lock up and then call `handleNotifyFork()` to avoid further 
+errors.
 
 #### Example
 ```php
 try {
     \Phpfastcache\Drivers\Couchbasev4\Driver::prepareToFork();
     $pid = pcntl_fork();
+    \Phpfastcache\Drivers\Couchbasev4\Driver::handleNotifyFork();
     if ($pid == -1) {
         // There was a problem with forking the process
     } else if ($pid) {

--- a/lib/Phpfastcache/Extensions/Drivers/Couchbasev4/Driver.php
+++ b/lib/Phpfastcache/Extensions/Drivers/Couchbasev4/Driver.php
@@ -199,8 +199,12 @@ class Driver implements AggregatablePoolInterface
         }
     }
 
-    protected static function handleNotifyFork(): void
+    public static function handleNotifyFork(): void
     {
+        if (!isset(static::$posixLoaded) && !isset(static::$extVersion)) {
+            return;
+        }
+
         if (static::$prepareToForkPPID && \version_compare(static::$extVersion, '4.2.1', '>=')) {
             if (static::$prepareToForkPPID === \posix_getpid()) {
                 Cluster::notifyFork(ForkEvent::PARENT);

--- a/tests/Couchbasev4.test.php
+++ b/tests/Couchbasev4.test.php
@@ -82,6 +82,7 @@ if($cache->set('bigTTL', 'test', new DateInterval('PT1576800001S'))) {
 try {
     \Phpfastcache\Extensions\Drivers\Couchbasev4\Driver::prepareToFork();
     $pid = \pcntl_fork();
+    \Phpfastcache\Extensions\Drivers\Couchbasev4\Driver::handleNotifyFork();
     if ($pid == -1) {
         $testHelper->assertFail('Unable to fork');
     } else if ($pid) {


### PR DESCRIPTION
The couchbase SDK now needs the parent and child processes to be notified at the same point.